### PR TITLE
Bugs on emacs-25.1. The warning messages:

### DIFF
--- a/src/jsx-mode.el
+++ b/src/jsx-mode.el
@@ -822,8 +822,9 @@ if there are any errors or warnings in `jsx-mode'."
   "Preserve the line feeds in documents
 cf. https://github.com/auto-complete/popup-el/issues/43"
   (when jsx--try-to-show-document-p
-    (beginning-of-buffer)
-    (replace-string "\n" jsx--hard-line-feed)
+    (goto-char (point-min))
+    (while (search-forward "\n") 
+           (replace-match jsx--hard-line-feed))
     (setq use-hard-newlines t)))
 
 (defun jsx--sort-docs (a b)


### PR DESCRIPTION
Warning (bytecomp): ‘beginning-of-buffer’ is for interactive use only;
use ‘(goto-char (point-min))’ instead.
Warning (bytecomp): ‘replace-string’ is for interactive use only; use
‘search-forward’ and ‘replace-match’ instead.
I am not sure if my fix is perfect but it definitely removes the above
warning messages since I followed its suggestions.